### PR TITLE
created facility_caretaker viewset

### DIFF
--- a/musicmemory/urls.py
+++ b/musicmemory/urls.py
@@ -19,7 +19,7 @@ from rest_framework import routers
 from rest_framework.authtoken.views import obtain_auth_token
 from musicmemoryapi.views import CaretakerView, UserView, FacilityView, SongView, MoodView
 from musicmemoryapi.views import EyeContactView, MovementView, TalkativenessView, VocalizationView
-from musicmemoryapi.views import LikedSongView, PatientView
+from musicmemoryapi.views import LikedSongView, PatientView, FacilityCaretakerView
 from musicmemoryapi.views import register_user, login_user
 
 router = routers.DefaultRouter(trailing_slash=False)
@@ -34,6 +34,8 @@ router.register(r'talkativeness', TalkativenessView, 'talkativeness')
 router.register(r'vocalizations', VocalizationView, 'vocalization')
 router.register(r'likedsongs', LikedSongView, 'likedsong')
 router.register(r'patients', PatientView, 'patient')
+router.register(r'facilitiescaretakers',
+                FacilityCaretakerView, 'facilitycaretaker')
 
 urlpatterns = [
     path('', include(router.urls)),

--- a/musicmemoryapi/views/__init__.py
+++ b/musicmemoryapi/views/__init__.py
@@ -10,3 +10,4 @@ from .talkativeness import TalkativenessView
 from .vocalization import VocalizationView
 from .liked_song import LikedSongView
 from .patient import PatientView
+from .facility_caretaker import FacilityCaretakerView

--- a/musicmemoryapi/views/facility_caretaker.py
+++ b/musicmemoryapi/views/facility_caretaker.py
@@ -22,7 +22,7 @@ class FacilityCaretakerSerializer(serializers.HyperlinkedModelSerializer):
             view_name='facilities_caretakers',
             lookup_field='id'
         )
-        fields = ('id', 'caretaker', 'caretaker_id' 'facility', 'facility_id')
+        fields = ('id', 'caretaker', 'caretaker_id', 'facility', 'facility_id')
         depth = 2
 
 


### PR DESCRIPTION
# Description
I added the create, list, retrieve facility_caretaker Viewset 
Fixes # (ability to access on the frontend props of facilities on Patient)
## Type of change
Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
# Testing Instructions
In Postman, got to http://127.0.0.1:8000/register/ and make a POST request using 

{
        "username": "TestUser",
        "email":"TestUser123@gmail.com",
        "password" :"123",
        "first_name": "Test",
        "last_name" : "Testerson",
        "title": "Nurse"
}
<img width="587" alt="Screen Shot 2020-09-12 at 10 37 54 PM" src="https://user-images.githubusercontent.com/58920011/93009593-9d13ea80-f548-11ea-993f-5d67c1632bcf.png">

Take the Token and add it to Headers 
<img width="820" alt="Screen Shot 2020-09-12 at 10 39 10 PM" src="https://user-images.githubusercontent.com/58920011/93009621-c896d500-f548-11ea-8cf2-3f5e7f5d7b23.png">

Then make a Facility. 
Go to http://127.0.0.1:8000/facilities and make a POST request.
In the body add this information:

{
       "facility_name": "Test Facility",
        "address": "123 TestFacility Ave"
}


if you need to remember the id your Caretaker got assigned on register, make a GET request to http://127.0.0.1:8000/caretakers


Then go to http://127.0.0.1:8000/facilitiescaretakers and select POST, in the Body place this dummy data:

{
    "caretaker_id": 1,
    "facility_id": 1
}
Then you can make a GET request to http://127.0.0.1:8000/facilitiescaretakers and make sure it POSTed


# Checklist:
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works